### PR TITLE
Feature: todo failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@ var re = {
     ].join('')),
     plan: /^(\d+)\.\.(\d+)\b/,
     comment: /^#\s*(.+)/,
-    version: /^TAP\s+version\s+(\d+)/i
+    version: /^TAP\s+version\s+(\d+)/i,
+    label_todo: /^(.*?)\s*#\s*TODO\s+(.*)$/,
 };
 
 function writable (s) {
@@ -30,13 +31,16 @@ module.exports = function (cb) {
         asserts: [],
         pass: [],
         fail: [],
+        todo: [],
         errors: []
     };
     
     stream.on('assert', function (res) {
         results.asserts.push(res);
-        if (!res.ok) results.ok = false;
-        (res.ok ? results.pass : results.fail).push(res);
+        if (!res.ok && !res.todo) results.ok = false;
+        var dest = (res.ok ? results.pass : results.fail);
+        if (res.todo) dest = results.todo;
+        dest.push(res);
         
         var prev = results.asserts[results.asserts.length - 2];
         if (prev && prev.number + 1 !== res.number) {
@@ -136,6 +140,11 @@ module.exports = function (cb) {
             var ok = !m[1];
             var num = m[2] && Number(m[2]);
             var name = m[3];
+            var asrt = {
+                ok: ok,
+                number: num,
+                name: name
+            };
             
             if (num === undefined) {
                 return stream.emit('parseError', {
@@ -143,11 +152,12 @@ module.exports = function (cb) {
                 });
             }
             
-            stream.emit('assert', {
-                ok: ok,
-                number: num,
-                name: name
-            });
+            if (m = re.label_todo.exec(name)) {
+                asrt.name = m[1];
+                asrt.todo = m[2];
+            }
+            
+            stream.emit('assert', asrt);
         }
         else if (m = re.plan.exec(line)) {
             stream.emit('plan', {

--- a/readme.markdown
+++ b/readme.markdown
@@ -52,6 +52,7 @@ $ node test.js | node parse.js
      { ok: true, number: 3, name: 'should be equal' },
      { ok: true, number: 4, name: '(unnamed assert)' } ],
   fail: [],
+  todo: [],
   errors: [],
   plan: { start: 1, end: 4 } }
 ```
@@ -81,9 +82,17 @@ Every `/^(not )?ok\b/` line will emit an `'assert'` event.
 
 Every `assert` object has these keys:
 
-`assert.ok` - true if the assertion succeeded, false if failed
-`assert.number` - the assertion number
-`assert.name` - optional short description of the assertion
+* `assert.ok` - true if the assertion succeeded, false if failed
+* `assert.number` - the assertion number
+* `assert.name` - optional short description of the assertion
+
+and may also have
+
+* `assert.todo` - optional description of why the assertion failure is
+  not a problem.
+
+When `results` are returned, each `assert` object will have been
+appended to the list `asserts` and one of (`pass`, `fail`, `todo`).
 
 ## p.on('comment', function (comment) {})
 

--- a/test/not_ok_todo.js
+++ b/test/not_ok_todo.js
@@ -1,0 +1,76 @@
+var test = require('tape');
+var parser = require('../');
+
+var lines = [
+    '# TAP emitted by Test::More 0.98',
+    'ok 1 - should be equal',
+    'not ok 2 - should be equivalent # TODO but we will fix it later',
+    '# boop',
+    'ok 3 - should be equal',
+    'ok 4 - (unnamed assert)',
+    '',
+    '1..4',
+    '# Looks like you failed 1 test of 4.',
+];
+
+var expected = { asserts: [], comments: [] };
+
+expected.comments = [ 'TAP emitted by Test::More 0.98', 'boop', 'Looks like you failed 1 test of 4.' ];
+
+expected.asserts.push({
+    ok: true,
+    number: 1,
+    name: 'should be equal'
+});
+expected.asserts.push({
+    ok: false,
+    number: 2,
+    name: 'should be equivalent',
+    todo: 'but we will fix it later',
+});
+expected.asserts.push({
+    ok: true,
+    number: 3,
+    name: 'should be equal'
+});
+expected.asserts.push({ 
+    ok: true,
+    number: 4,
+    name: '(unnamed assert)'
+});
+
+test('not ok, but todo', function (t) {
+    t.plan(7 * 2 + 1 + 3 + 4);
+    
+    var p = parser(onresults);
+    p.on('results', onresults);
+    
+    var asserts = [];
+    p.on('assert', function (assert) {
+        asserts.push(assert);
+        t.same(assert, expected.asserts.shift(), 'next assert');
+    });
+    
+    p.on('plan', function (plan) {
+        t.same(plan, { start: 1, end: 4 }, 'plan');
+    });
+    
+    p.on('comment', function (c) {
+        t.equal(c, expected.comments.shift(), 'next comment');
+    });
+    
+    for (var i = 0; i < lines.length; i++) {
+        p.write(lines[i] + '\n');
+    }
+    p.end();
+    
+    function onresults (results) {
+        t.equal(results.ok, true, 'onresults: ok');
+        t.equal(results.asserts.length, 4);
+        t.equal(results.pass.length, 3, 'onresults: pass.length');
+        t.equal(results.fail.length, 0, 'onresults: fail.length');
+        t.equal(results.todo.length, 1, 'onresults: todo.length');
+        t.same(results.errors, []);
+        t.same(results.asserts, asserts);
+    }
+});


### PR DESCRIPTION
Hi again,

I needed to parse some TAP from Perl's Test::More, including `not ok - 4 got my 5-a-day # TODO fix it after eating some cookies`
so I added test, fix + doc.

Is this useful?  Can you merge please?
