### PR TITLE
added readable-stream for 0.8 compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Writable = require('stream').Writable;
+var Writable = require('readable-stream').Writable;
 var inherits = require('inherits');
 
 var re = {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "parse the test anything protocol",
   "main": "index.js",
   "dependencies": {
-    "inherits": "~2.0.1"
+    "inherits": "~2.0.1",
+    "readable-stream": "~1.0.25"
   },
   "devDependencies": {
     "tape": "~2.3.2",
@@ -17,8 +18,10 @@
     "files": "test/*.js",
     "browsers": [
       "ie/6..latest",
-      "chrome/10", "chrome/latest",
-      "firefox/3.5", "firefox/latest",
+      "chrome/10",
+      "chrome/latest",
+      "firefox/3.5",
+      "firefox/latest",
       "opera/latest",
       "safari/latest"
     ]


### PR DESCRIPTION
Anything that I use that depends on tap-parser (faucet) fails on 0.8 because of this.

Just not sure how you prefer to deal with readable-stream & browserify atm, suggestions?
