### PR TITLE
Drop inherits from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "events-to-array": "^1.0.1",
-    "inherits": "~2.0.1",
     "js-yaml": "^3.2.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Use of inherits was dropped in c4e0246972fc343fcfbd55020e2bd9ce2dd064bc but it's still listed as a dependency.