### PR TITLE
Treat empty tests the same as a 'skip all' 1..0

### DIFF
--- a/index.js
+++ b/index.js
@@ -333,7 +333,13 @@ Parser.prototype.end = function (chunk, encoding, cb) {
       this.tapError('Plan of 1..0, but test points encountered')
     }
   } else if (!this.bailedOut && this.planStart === -1) {
-    this.tapError('no plan')
+    if (this.count === 0) {
+      this.planStart = 1
+      this.planEnd = 0
+      skipAll = true
+    } else {
+      this.tapError('no plan')
+    }
   } else if (this.ok && this.count !== (this.planEnd - this.planStart + 1)) {
     this.tapError('incorrect number of tests')
   }

--- a/test/fixtures/die.json
+++ b/test/fixtures/die.json
@@ -5,16 +5,11 @@
       "ok": true,
       "count": 0,
       "pass": 0,
-      "fail": 1,
       "plan": {
         "start": 1,
         "end": 0
       },
-      "failures": [
-        {
-          "tapError": "no plan"
-        }
-      ]
+      "failures": []
     }
   ]
 ]

--- a/test/fixtures/empty.json
+++ b/test/fixtures/empty.json
@@ -5,16 +5,11 @@
       "ok": true,
       "count": 0,
       "pass": 0,
-      "fail": 1,
       "plan": {
         "start": 1,
         "end": 0
       },
-      "failures": [
-        {
-          "tapError": "no plan"
-        }
-      ]
+      "failures": []
     }
   ]
 ]

--- a/test/fixtures/indented-stdout-noise.json
+++ b/test/fixtures/indented-stdout-noise.json
@@ -86,16 +86,11 @@
                   "ok": true,
                   "count": 0,
                   "pass": 0,
-                  "fail": 1,
                   "plan": {
                     "start": 1,
                     "end": 0
                   },
-                  "failures": [
-                    {
-                      "tapError": "no plan"
-                    }
-                  ]
+                  "failures": []
                 }
               ]
             ]
@@ -130,16 +125,11 @@
               "ok": true,
               "count": 0,
               "pass": 0,
-              "fail": 1,
               "plan": {
                 "start": 1,
                 "end": 0
               },
-              "failures": [
-                {
-                  "tapError": "no plan"
-                }
-              ]
+              "failures": []
             }
           ]
         ]

--- a/test/fixtures/out_err_mix.json
+++ b/test/fixtures/out_err_mix.json
@@ -21,16 +21,11 @@
       "ok": true,
       "count": 0,
       "pass": 0,
-      "fail": 1,
       "plan": {
         "start": 1,
         "end": 0
       },
-      "failures": [
-        {
-          "tapError": "no plan"
-        }
-      ]
+      "failures": []
     }
   ]
 ]


### PR DESCRIPTION
Node-tap jumps through a lot of hoops to treat empty subtest processes
as an empty test, by synthetically adding a `1..0` line to the stream if
no valid TAP output is encountered.

Why not just do that in the parser?  It simplifies a lot of stuff.

I doubt that anyone is depending on this being a failure, but just in
case, it should be a major version bump.