### PR TITLE
Fix #40: Emit empty results

### DIFF
--- a/index.js
+++ b/index.js
@@ -355,17 +355,35 @@ Parser.prototype.end = function (chunk, encoding, cb) {
     pass: this.pass
   }
 
-  if (this.fail)
+  if (this.fail) {
     final.fail = this.fail
+  } else {
+    final.fail = 0
+  }
 
-  if (this.bailedOut)
+  if (this.bailedOut) {
     final.bailout = this.bailedOut
+  } else {
+    final.bailout = false
+  }
 
-  if (this.todo)
+  if (this.todo) {
     final.todo = this.todo
+  } else {
+    final.todo = 0
+  }
 
-  if (this.skip)
-    final.skip = this.skip
+  // if they were all skipped, then skip = count
+  if (skipAll) {
+    final.skip = this.count;
+  } else {
+    // otherwise either get the skip count, or emit 0
+    if (this.skip) {
+      final.skip = this.skip
+    } else {
+      final.skip = 0
+    }
+  }
 
   if (this.planStart !== -1) {
     final.plan = { start: this.planStart, end: this.planEnd }
@@ -376,7 +394,7 @@ Parser.prototype.end = function (chunk, encoding, cb) {
     }
   }
 
-  if (this.failures.length) {
+  if (this.failures && this.failures.length) {
     final.failures = this.failures
   } else {
     final.failures = []

--- a/test/fixtures/bailout-no-raison.json
+++ b/test/fixtures/bailout-no-raison.json
@@ -57,11 +57,14 @@
       "ok": false,
       "count": 3,
       "pass": 3,
+      "todo": 0,
+      "skip": 0,
       "bailout": true,
       "plan": {
         "start": 1,
         "end": 5
       },
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/bailout.json
+++ b/test/fixtures/bailout.json
@@ -57,11 +57,14 @@
       "ok": false,
       "count": 3,
       "pass": 3,
+      "todo": 0,
+      "skip": 0,
       "bailout": "GERONIMMMOOOOOO!!!",
       "plan": {
         "start": 1,
         "end": 5
       },
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/basic.json
+++ b/test/fixtures/basic.json
@@ -76,6 +76,9 @@
         "start": 1,
         "end": 6
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/big-last.json
+++ b/test/fixtures/big-last.json
@@ -85,6 +85,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": true,

--- a/test/fixtures/bignum.json
+++ b/test/fixtures/bignum.json
@@ -67,6 +67,9 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": true,

--- a/test/fixtures/bignum_many.json
+++ b/test/fixtures/bignum_many.json
@@ -150,7 +150,10 @@
       "plan": {
         "start": 1,
         "end": 2
-      },
+      },      
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": true,

--- a/test/fixtures/broken-yamlish-looks-like-child.json
+++ b/test/fixtures/broken-yamlish-looks-like-child.json
@@ -88,6 +88,10 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/broken-yamlish-with-nonbroken-yamlish.json
+++ b/test/fixtures/broken-yamlish-with-nonbroken-yamlish.json
@@ -119,6 +119,10 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/child-extra.json
+++ b/test/fixtures/child-extra.json
@@ -91,6 +91,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -190,6 +194,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/combined.json
+++ b/test/fixtures/combined.json
@@ -144,6 +144,7 @@
         "start": 1,
         "end": 10
       },
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/combined_compat.json
+++ b/test/fixtures/combined_compat.json
@@ -129,6 +129,8 @@
       "pass": 7,
       "fail": 4,
       "skip": 1,
+      "todo": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/comment-mid-diag-postplan.json
+++ b/test/fixtures/comment-mid-diag-postplan.json
@@ -144,6 +144,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -227,6 +231,9 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/comment-mid-diag.json
+++ b/test/fixtures/comment-mid-diag.json
@@ -131,6 +131,9 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/common-with-explanation.json
+++ b/test/fixtures/common-with-explanation.json
@@ -132,6 +132,10 @@
         "start": 1,
         "end": 6
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/creative-liberties.json
+++ b/test/fixtures/creative-liberties.json
@@ -206,6 +206,10 @@
         "start": 1,
         "end": 9
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/delayed.json
+++ b/test/fixtures/delayed.json
@@ -78,6 +78,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/descriptive.json
+++ b/test/fixtures/descriptive.json
@@ -80,6 +80,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/descriptive_trailing.json
+++ b/test/fixtures/descriptive_trailing.json
@@ -80,6 +80,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/die.json
+++ b/test/fixtures/die.json
@@ -21,6 +21,10 @@
         "end": 0,
         "skipAll": true
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/die_head_end.json
+++ b/test/fixtures/die_head_end.json
@@ -50,6 +50,9 @@
       "count": 4,
       "pass": 4,
       "fail": 1,
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "no plan"

--- a/test/fixtures/die_last_minute.json
+++ b/test/fixtures/die_last_minute.json
@@ -64,6 +64,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/die_unfinished.json
+++ b/test/fixtures/die_unfinished.json
@@ -54,6 +54,9 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/duplicates.json
+++ b/test/fixtures/duplicates.json
@@ -142,6 +142,9 @@
         "start": 1,
         "end": 10
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/echo.json
+++ b/test/fixtures/echo.json
@@ -21,6 +21,10 @@
         "end": 0,
         "skipAll": true
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/empty-failures.json
+++ b/test/fixtures/empty-failures.json
@@ -42,6 +42,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/empty.json
+++ b/test/fixtures/empty.json
@@ -21,6 +21,10 @@
         "end": 0,
         "skipAll": true
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/escape_eol.json
+++ b/test/fixtures/escape_eol.json
@@ -44,6 +44,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/escape_hash.json
+++ b/test/fixtures/escape_hash.json
@@ -56,6 +56,10 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/extra-in-child.json
+++ b/test/fixtures/extra-in-child.json
@@ -82,6 +82,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -156,6 +160,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -419,6 +427,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -618,6 +630,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/garbage-yamlish.json
+++ b/test/fixtures/garbage-yamlish.json
@@ -125,6 +125,9 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/giving-up.json
+++ b/test/fixtures/giving-up.json
@@ -50,6 +50,8 @@
         "start": 1,
         "end": 573
       },
+      "todo": 0,
+      "skip": 0,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/got-spare-tuits.json
+++ b/test/fixtures/got-spare-tuits.json
@@ -80,6 +80,8 @@
         "start": 1,
         "end": 4
       },
+      "skip": 0,
+      "bailout": false,
       "failures": []
     }
   ]

--- a/test/fixtures/head_end.json
+++ b/test/fixtures/head_end.json
@@ -96,6 +96,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/head_fail.json
+++ b/test/fixtures/head_fail.json
@@ -97,6 +97,9 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/implicit-counter.json
+++ b/test/fixtures/implicit-counter.json
@@ -124,6 +124,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/indent.json
+++ b/test/fixtures/indent.json
@@ -84,6 +84,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -257,6 +261,7 @@
                 "start": 1,
                 "end": 3
               },
+              "bailout": false,
               "failures": []
             }
           ]
@@ -348,6 +353,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -444,6 +453,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/indented-stdout-noise.json
+++ b/test/fixtures/indented-stdout-noise.json
@@ -102,6 +102,10 @@
                     "end": 0,
                     "skipAll": true
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -153,6 +157,10 @@
                 "end": 0,
                 "skipAll": true
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -464,6 +472,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -757,6 +769,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/junk_before_plan.json
+++ b/test/fixtures/junk_before_plan.json
@@ -47,6 +47,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/line-break.json
+++ b/test/fixtures/line-break.json
@@ -104,6 +104,9 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
           "failures": [
             {
               "ok": false,
@@ -275,6 +278,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/lone_not_bug.json
+++ b/test/fixtures/lone_not_bug.json
@@ -64,6 +64,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/missing.json
+++ b/test/fixtures/missing.json
@@ -84,6 +84,9 @@
         "start": 1,
         "end": 6
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/no-numbers.json
+++ b/test/fixtures/no-numbers.json
@@ -57,6 +57,9 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/no-plan.json
+++ b/test/fixtures/no-plan.json
@@ -78,6 +78,9 @@
       "count": 4,
       "pass": 4,
       "fail": 1,
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "no plan"

--- a/test/fixtures/no_nums.json
+++ b/test/fixtures/no_nums.json
@@ -76,6 +76,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/not-enough.json
+++ b/test/fixtures/not-enough.json
@@ -117,6 +117,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/not-ok-todo.json
+++ b/test/fixtures/not-ok-todo.json
@@ -95,6 +95,8 @@
         "start": 1,
         "end": 4
       },
+      "skip": 0,
+      "bailout": false,
       "failures": []
     }
   ]

--- a/test/fixtures/not-ok.json
+++ b/test/fixtures/not-ok.json
@@ -117,6 +117,9 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/offset-mismatch.json
+++ b/test/fixtures/offset-mismatch.json
@@ -117,6 +117,9 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "first test id does not match plan start"

--- a/test/fixtures/offset.json
+++ b/test/fixtures/offset.json
@@ -116,6 +116,10 @@
         "start": 8,
         "end": 11
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/ok.json
+++ b/test/fixtures/ok.json
@@ -116,6 +116,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/one-ok.json
+++ b/test/fixtures/one-ok.json
@@ -39,6 +39,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/out-of-order.json
+++ b/test/fixtures/out-of-order.json
@@ -116,6 +116,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/out_err_mix.json
+++ b/test/fixtures/out_err_mix.json
@@ -37,6 +37,10 @@
         "end": 0,
         "skipAll": true
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/out_of_order.json
+++ b/test/fixtures/out_of_order.json
@@ -181,6 +181,9 @@
         "start": 1,
         "end": 15
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/outside-plan.json
+++ b/test/fixtures/outside-plan.json
@@ -67,6 +67,9 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": true,

--- a/test/fixtures/perl-test2-buffered.json
+++ b/test/fixtures/perl-test2-buffered.json
@@ -44,6 +44,10 @@
             "end": 0,
             "skipAll": true
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -121,6 +125,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -206,6 +214,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -291,6 +303,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -376,6 +392,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -423,6 +443,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/perl-test2-streamed.json
+++ b/test/fixtures/perl-test2-streamed.json
@@ -67,6 +67,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -152,6 +156,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -198,6 +206,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/plan-in-bad-places-post.json
+++ b/test/fixtures/plan-in-bad-places-post.json
@@ -62,6 +62,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -165,6 +169,9 @@
         "start": 1,
         "end": 99
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/plan-in-bad-places-pre.json
+++ b/test/fixtures/plan-in-bad-places-pre.json
@@ -81,6 +81,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -164,6 +168,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/pragma-mid-child-strict.json
+++ b/test/fixtures/pragma-mid-child-strict.json
@@ -70,6 +70,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -113,6 +117,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "Non-TAP data encountered in strict mode",

--- a/test/fixtures/pragma-mid-child.json
+++ b/test/fixtures/pragma-mid-child.json
@@ -66,6 +66,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -104,6 +108,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/pragma-mid-yaml.json
+++ b/test/fixtures/pragma-mid-yaml.json
@@ -78,6 +78,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/schwern-todo-quiet.json
+++ b/test/fixtures/schwern-todo-quiet.json
@@ -113,6 +113,8 @@
         "start": 1,
         "end": 3
       },
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/schwern.json
+++ b/test/fixtures/schwern.json
@@ -32,6 +32,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/sequence_misparse.json
+++ b/test/fixtures/sequence_misparse.json
@@ -92,6 +92,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/simple.json
+++ b/test/fixtures/simple.json
@@ -75,6 +75,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/simple_fail.json
+++ b/test/fixtures/simple_fail.json
@@ -76,6 +76,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/simple_yaml.json
+++ b/test/fixtures/simple_yaml.json
@@ -177,6 +177,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/simple_yaml_missing_version13.json
+++ b/test/fixtures/simple_yaml_missing_version13.json
@@ -169,6 +169,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skip-all-nonempty.json
+++ b/test/fixtures/skip-all-nonempty.json
@@ -41,6 +41,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skip-all-with-assert.json
+++ b/test/fixtures/skip-all-with-assert.json
@@ -39,6 +39,10 @@
         "skipAll": true,
         "skipReason": "SKIP Insufficient skipping"
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skip-all-with-test.json
+++ b/test/fixtures/skip-all-with-test.json
@@ -41,6 +41,9 @@
         "end": 0,
         "skipAll": true
       },
+      "todo": 0,
+      "skip": 1,
+      "bailout": false,
       "failures": [
         {
           "tapError": "Plan of 1..0, but test points encountered"

--- a/test/fixtures/skip-all.json
+++ b/test/fixtures/skip-all.json
@@ -31,6 +31,10 @@
         "skipAll": true,
         "skipReason": "SKIP Insufficient positron flux"
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skip-one-fail.json
+++ b/test/fixtures/skip-one-fail.json
@@ -43,6 +43,8 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "bailout": false,
       "failures": []
     }
   ]

--- a/test/fixtures/skip-one-ok.json
+++ b/test/fixtures/skip-one-ok.json
@@ -42,6 +42,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skip.json
+++ b/test/fixtures/skip.json
@@ -78,6 +78,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skip_nomsg.json
+++ b/test/fixtures/skip_nomsg.json
@@ -34,6 +34,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skipall.json
+++ b/test/fixtures/skipall.json
@@ -16,6 +16,7 @@
     {
       "ok": true,
       "count": 0,
+      "skip": 0,
       "pass": 0,
       "plan": {
         "start": 1,
@@ -23,6 +24,9 @@
         "skipAll": true,
         "skipReason": "skipping: rope"
       },
+      "todo": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skipall_nomsg.json
+++ b/test/fixtures/skipall_nomsg.json
@@ -21,6 +21,10 @@
         "end": 0,
         "skipAll": true
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skipall_v13.json
+++ b/test/fixtures/skipall_v13.json
@@ -31,6 +31,10 @@
         "skipAll": true,
         "skipReason": "skipping: rope"
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/skipping-a-few.json
+++ b/test/fixtures/skipping-a-few.json
@@ -101,6 +101,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/space_after_plan.json
+++ b/test/fixtures/space_after_plan.json
@@ -74,6 +74,9 @@
       "count": 5,
       "pass": 5,
       "fail": 1,
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "no plan"

--- a/test/fixtures/stdout_stderr.json
+++ b/test/fixtures/stdout_stderr.json
@@ -64,6 +64,10 @@
         "start": 1,
         "end": 4
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/strict.json
+++ b/test/fixtures/strict.json
@@ -75,6 +75,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "Non-TAP data encountered in strict mode",

--- a/test/fixtures/subtest-buffer-todo.json
+++ b/test/fixtures/subtest-buffer-todo.json
@@ -54,6 +54,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -123,6 +127,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -168,6 +176,8 @@
         "start": 1,
         "end": 2
       },
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-buffer.json
+++ b/test/fixtures/subtest-buffer.json
@@ -93,6 +93,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -190,6 +194,10 @@
                 "start": 1,
                 "end": 3
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -229,6 +237,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -331,6 +343,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-comment-indent.json
+++ b/test/fixtures/subtest-comment-indent.json
@@ -85,6 +85,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -183,6 +187,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -238,6 +246,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -345,6 +357,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -460,6 +476,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-comment-leading.json
+++ b/test/fixtures/subtest-comment-leading.json
@@ -90,6 +90,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -188,6 +192,10 @@
                 "start": 1,
                 "end": 3
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -239,6 +247,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -342,6 +354,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-comment-mixed-indent.json
+++ b/test/fixtures/subtest-comment-mixed-indent.json
@@ -93,6 +93,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -191,6 +195,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -242,6 +250,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -345,6 +357,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -460,6 +476,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-comment-noindent.json
+++ b/test/fixtures/subtest-comment-noindent.json
@@ -97,6 +97,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -195,6 +199,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -246,6 +254,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -349,6 +361,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -460,6 +476,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-confusing.json
+++ b/test/fixtures/subtest-confusing.json
@@ -78,6 +78,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -124,6 +128,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -190,6 +198,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-heading.json
+++ b/test/fixtures/subtest-heading.json
@@ -70,6 +70,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -116,6 +120,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -174,6 +182,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-maybe-child-unfulfilled.json
+++ b/test/fixtures/subtest-maybe-child-unfulfilled.json
@@ -98,6 +98,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -140,6 +144,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -202,6 +210,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-mixing.json
+++ b/test/fixtures/subtest-mixing.json
@@ -78,6 +78,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -120,6 +124,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -216,6 +224,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -258,6 +270,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -350,6 +366,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -396,6 +416,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -492,6 +516,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -534,6 +562,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -630,6 +662,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -672,6 +708,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -764,6 +804,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -810,6 +854,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -902,6 +950,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -944,6 +996,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -1040,6 +1096,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -1082,6 +1142,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -1174,6 +1238,10 @@
                 "start": 1,
                 "end": 1
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -1220,6 +1288,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -1278,6 +1350,10 @@
         "start": 1,
         "end": 9
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-no-comment-leading-comment.json
+++ b/test/fixtures/subtest-no-comment-leading-comment.json
@@ -89,6 +89,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -183,6 +187,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -234,6 +242,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -321,6 +333,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -408,6 +424,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-no-comment-mid-comment-indent.json
+++ b/test/fixtures/subtest-no-comment-mid-comment-indent.json
@@ -85,6 +85,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -179,6 +183,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -230,6 +238,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -321,6 +333,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -412,6 +428,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-no-comment-mid-comment.json
+++ b/test/fixtures/subtest-no-comment-mid-comment.json
@@ -85,6 +85,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -179,6 +183,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -230,6 +238,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -321,6 +333,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -412,6 +428,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-no-comment.json
+++ b/test/fixtures/subtest-no-comment.json
@@ -85,6 +85,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -179,6 +183,10 @@
                     "start": 1,
                     "end": 3
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -230,6 +238,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -317,6 +329,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -404,6 +420,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-stream-comment-indent.json
+++ b/test/fixtures/subtest-stream-comment-indent.json
@@ -93,6 +93,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -191,6 +195,10 @@
                 "start": 1,
                 "end": 3
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -235,6 +243,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -342,6 +354,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-stream-comment.json
+++ b/test/fixtures/subtest-stream-comment.json
@@ -93,6 +93,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -191,6 +195,10 @@
                 "start": 1,
                 "end": 3
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -231,6 +239,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -334,6 +346,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-stream-no-comment.json
+++ b/test/fixtures/subtest-stream-no-comment.json
@@ -85,6 +85,10 @@
                 "start": 1,
                 "end": 2
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -179,6 +183,10 @@
                 "start": 1,
                 "end": 3
               },
+              "todo": 0,
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -219,6 +227,10 @@
             "start": 1,
             "end": 2
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -306,6 +318,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/subtest-unfinished.json
+++ b/test/fixtures/subtest-unfinished.json
@@ -72,6 +72,10 @@
             "start": 1,
             "end": 1
           },
+          "todo": 0,
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -95,6 +99,10 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/switches.json
+++ b/test/fixtures/switches.json
@@ -32,6 +32,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/tap-tests-stdout.json
+++ b/test/fixtures/tap-tests-stdout.json
@@ -5949,6 +5949,7 @@
         "start": 1,
         "end": 312
       },
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/tap-tests.json
+++ b/test/fixtures/tap-tests.json
@@ -6105,6 +6105,7 @@
         "start": 1,
         "end": 311
       },
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/todo.json
+++ b/test/fixtures/todo.json
@@ -137,6 +137,10 @@
                     "start": 1,
                     "end": 2
                   },
+                  "todo": 0,
+                  "skip": 0,
+                  "bailout": false,
+                  "fail": 0,
                   "failures": []
                 }
               ]
@@ -188,6 +192,9 @@
                 "start": 1,
                 "end": 3
               },
+              "skip": 0,
+              "bailout": false,
+              "fail": 0,
               "failures": []
             }
           ]
@@ -259,6 +266,9 @@
             "start": 1,
             "end": 3
           },
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -400,6 +410,9 @@
             "start": 1,
             "end": 3
           },
+          "skip": 0,
+          "bailout": false,
+          "fail": 0,
           "failures": []
         }
       ]
@@ -454,6 +467,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/todo_inline.json
+++ b/test/fixtures/todo_inline.json
@@ -60,6 +60,8 @@
         "start": 1,
         "end": 3
       },
+      "skip": 0,
+      "bailout": false,
       "failures": []
     }
   ]

--- a/test/fixtures/todo_misparse.json
+++ b/test/fixtures/todo_misparse.json
@@ -33,6 +33,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/too-many.json
+++ b/test/fixtures/too-many.json
@@ -117,6 +117,9 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/too_many.json
+++ b/test/fixtures/too_many.json
@@ -102,6 +102,9 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": true,

--- a/test/fixtures/unfinished.json
+++ b/test/fixtures/unfinished.json
@@ -51,6 +51,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "incorrect number of tests"

--- a/test/fixtures/unknown-amount-and-failures.json
+++ b/test/fixtures/unknown-amount-and-failures.json
@@ -161,6 +161,9 @@
         "start": 1,
         "end": 7
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/version_good.json
+++ b/test/fixtures/version_good.json
@@ -83,6 +83,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/version_late.json
+++ b/test/fixtures/version_late.json
@@ -83,6 +83,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/version_old-strict.json
+++ b/test/fixtures/version_old-strict.json
@@ -93,6 +93,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "Non-TAP data encountered in strict mode",

--- a/test/fixtures/version_old.json
+++ b/test/fixtures/version_old.json
@@ -83,6 +83,10 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/vms_nit.json
+++ b/test/fixtures/vms_nit.json
@@ -50,6 +50,10 @@
         "start": 1,
         "end": 2
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/with_comments.json
+++ b/test/fixtures/with_comments.json
@@ -119,6 +119,9 @@
       "count": 5,
       "pass": 3,
       "fail": 3,
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/wrong-last.json
+++ b/test/fixtures/wrong-last.json
@@ -84,6 +84,9 @@
         "start": 1,
         "end": 5
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "tapError": "last test id does not match plan end"

--- a/test/fixtures/yaml_late_plan.json
+++ b/test/fixtures/yaml_late_plan.json
@@ -79,6 +79,10 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/yamlish-looks-like-child.json
+++ b/test/fixtures/yamlish-looks-like-child.json
@@ -82,6 +82,10 @@
         "start": 1,
         "end": 3
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/yamlish-that-is-not-yaml.json
+++ b/test/fixtures/yamlish-that-is-not-yaml.json
@@ -137,6 +137,9 @@
         "start": 1,
         "end": 1
       },
+      "todo": 0,
+      "skip": 0,
+      "bailout": false,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/yamlish-without-test.json
+++ b/test/fixtures/yamlish-without-test.json
@@ -72,6 +72,10 @@
         "start": 1,
         "end": 1
       },
+      "bailout": false,
+      "todo": 0,
+      "skip": 0,
+      "fail": 0,
       "failures": []
     }
   ]

--- a/test/fixtures/yamlish.json
+++ b/test/fixtures/yamlish.json
@@ -99,6 +99,9 @@
         "start": 1,
         "end": 1
       },
+      "bailout": false,
+      "skip": 0,
+      "todo": 0,
       "failures": [
         {
           "ok": false,

--- a/test/fixtures/zero_valid.json
+++ b/test/fixtures/zero_valid.json
@@ -82,6 +82,9 @@
         "start": 1,
         "end": 5
       },
+      "bailout": false,
+      "skip": 0,
+      "todo": 0,
       "failures": [
         {
           "ok": true,

--- a/test/write-after-bailout.js
+++ b/test/write-after-bailout.js
@@ -33,12 +33,15 @@ t.test('child calling _parse after bailout', function (t) {
           { ok: false,
             count: 0,
             pass: 0,
+            fail: 0,
+            skip: 0,
+            todo: 0,
             bailout: 'child',
             plan: { start: 1, end: 1 },
             failures: [] } ] ] ],
     [ 'bailout', 'child' ],
     [ 'complete',
-      { ok: false, count: 0, pass: 0, bailout: 'child', failures: [] } ]
+      { ok: false, count: 0, pass: 0, fail: 0, skip: 0, todo: 0, bailout: 'child', failures: [] } ]
   ]
 
   p.on('assert', t.fail)


### PR DESCRIPTION
This makes the following changes:

* Emit `fail` as `0` if there are no failures
* Emit `skip` as `0` if there were no skips, or as `count` if they were all skipped (`1..0`)
* Emit `todo` as `0` if there were no todos
* Emit `bailout` as false if there was no bailout