### PR TITLE
Add freetext test

### DIFF
--- a/test/fixtures/yaml-freetext-folded.json
+++ b/test/fixtures/yaml-freetext-folded.json
@@ -1,0 +1,121 @@
+[
+  [
+    "line",
+    "TAP Version 13\n"
+  ],
+  [
+    "version",
+    13
+  ],
+  [
+    "line",
+    "1..1\n"
+  ],
+  [
+    "plan",
+    {
+      "start": 1,
+      "end": 1
+    }
+  ],
+  [
+    "line",
+    "not ok 1 Numbers equal\n"
+  ],
+  [
+    "line",
+    "  ---\n"
+  ],
+  [
+    "line",
+    "  message: \"Failed with error '42 is not 43'\"\n"
+  ],
+  [
+    "line",
+    "  severity: fail\n"
+  ],
+  [
+    "line",
+    "  data:\n"
+  ],
+  [
+    "line",
+    "    got: 42\n"
+  ],
+  [
+    "line",
+    "    expected: 43\n"
+  ],
+  [
+    "line",
+    "    label: >\n"
+  ],
+  [
+    "line",
+    "      Expected the test to give the value 43. This is integral to the running of the application.\n"
+  ],
+  [
+    "line",
+    "      However, I was only given the number\n"
+  ],
+  [
+    "line",
+    "      42\n"
+  ],
+  [
+    "line",
+    "  ...\n"
+  ],
+  [
+    "assert",
+    {
+      "ok": false,
+      "id": 1,
+      "name": "Numbers equal",
+      "diag": {
+        "message": "Failed with error '42 is not 43'",
+        "severity": "fail",
+        "data": {
+          "got": 42,
+          "expected": 43,
+          "label": "Expected the test to give the value 43. This is integral to the running of the application. However, I was only given the number 42\n"
+        }
+      }
+    }
+  ],
+  [
+    "complete",
+    {
+      "ok": false,
+      "count": 1,
+      "pass": 0,
+      "fail": 1,
+      "bailout": false,
+      "todo": 0,
+      "skip": 0,
+      "plan": {
+        "start": 1,
+        "end": 1,
+        "skipAll": false,
+        "skipReason": "",
+        "comment": ""
+      },
+      "failures": [
+        {
+          "ok": false,
+          "id": 1,
+          "name": "Numbers equal",
+          "diag": {
+            "message": "Failed with error '42 is not 43'",
+            "severity": "fail",
+            "data": {
+              "got": 42,
+              "expected": 43,
+              "label": "Expected the test to give the value 43. This is integral to the running of the application. However, I was only given the number 42\n"
+            }
+          }
+        }
+      ]
+    }
+  ]
+]

--- a/test/fixtures/yaml-freetext-folded.tap
+++ b/test/fixtures/yaml-freetext-folded.tap
@@ -1,0 +1,14 @@
+TAP Version 13
+1..1
+not ok 1 Numbers equal
+  ---
+  message: "Failed with error '42 is not 43'"
+  severity: fail
+  data:
+    got: 42
+    expected: 43
+    label: >
+      Expected the test to give the value 43. This is integral to the running of the application.
+      However, I was only given the number
+      42
+  ...

--- a/test/fixtures/yaml-freetext-literal.json
+++ b/test/fixtures/yaml-freetext-literal.json
@@ -1,0 +1,121 @@
+[
+  [
+    "line",
+    "TAP Version 13\n"
+  ],
+  [
+    "version",
+    13
+  ],
+  [
+    "line",
+    "1..1\n"
+  ],
+  [
+    "plan",
+    {
+      "start": 1,
+      "end": 1
+    }
+  ],
+  [
+    "line",
+    "not ok 1 Numbers equal\n"
+  ],
+  [
+    "line",
+    "  ---\n"
+  ],
+  [
+    "line",
+    "  message: \"Failed with error '42 is not 43'\"\n"
+  ],
+  [
+    "line",
+    "  severity: fail\n"
+  ],
+  [
+    "line",
+    "  data:\n"
+  ],
+  [
+    "line",
+    "    got: 42\n"
+  ],
+  [
+    "line",
+    "    expected: 43\n"
+  ],
+  [
+    "line",
+    "    label: |\n"
+  ],
+  [
+    "line",
+    "      Expected the test to give the value 43. This is integral to the running of the application.\n"
+  ],
+  [
+    "line",
+    "      However, I was only given the number\n"
+  ],
+  [
+    "line",
+    "      42\n"
+  ],
+  [
+    "line",
+    "  ...\n"
+  ],
+  [
+    "assert",
+    {
+      "ok": false,
+      "id": 1,
+      "name": "Numbers equal",
+      "diag": {
+        "message": "Failed with error '42 is not 43'",
+        "severity": "fail",
+        "data": {
+          "got": 42,
+          "expected": 43,
+          "label": "Expected the test to give the value 43. This is integral to the running of the application.\nHowever, I was only given the number\n42\n"
+        }
+      }
+    }
+  ],
+  [
+    "complete",
+    {
+      "ok": false,
+      "count": 1,
+      "pass": 0,
+      "fail": 1,
+      "bailout": false,
+      "todo": 0,
+      "skip": 0,
+      "plan": {
+        "start": 1,
+        "end": 1,
+        "skipAll": false,
+        "skipReason": "",
+        "comment": ""
+      },
+      "failures": [
+        {
+          "ok": false,
+          "id": 1,
+          "name": "Numbers equal",
+          "diag": {
+            "message": "Failed with error '42 is not 43'",
+            "severity": "fail",
+            "data": {
+              "got": 42,
+              "expected": 43,
+              "label": "Expected the test to give the value 43. This is integral to the running of the application.\nHowever, I was only given the number\n42\n"
+            }
+          }
+        }
+      ]
+    }
+  ]
+]

--- a/test/fixtures/yaml-freetext-literal.tap
+++ b/test/fixtures/yaml-freetext-literal.tap
@@ -1,0 +1,14 @@
+TAP Version 13
+1..1
+not ok 1 Numbers equal
+  ---
+  message: "Failed with error '42 is not 43'"
+  severity: fail
+  data:
+    got: 42
+    expected: 43
+    label: |
+      Expected the test to give the value 43. This is integral to the running of the application.
+      However, I was only given the number
+      42
+  ...


### PR DESCRIPTION
It would be good to get some tests around the freetext feature in YAML. This is something we plan to use in [alsatian-test/alsatian](https://github.com/alsatian-test/alsatian) and [alsatian-test/tap-bark](https://github.com/alsatian-test/tap-bark) so it would be good to have some security around it (no test coverage at the moment).