### PR TITLE
align with docs, instantiate Parser class

### DIFF
--- a/example/parse.js
+++ b/example/parse.js
@@ -1,5 +1,5 @@
 var parser = require('../');
-var p = parser(function (results) {
+var p = new Parser(function (results) {
     console.dir(results);
 });
 process.stdin.pipe(p);


### PR DESCRIPTION
Should instantiate a class with `new`, otherwise the example throws errors with later versions of Node.