### PR TITLE
cmd: prevent exiting before stdout flush

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -161,6 +161,6 @@ if (json === 'lines' || json === 'silent') {
     const summary = result[ result.length - 1 ]
     console.log(format(result))
     if (summary[0] !== 'complete' || !summary[1].ok)
-      process.exit(1)
+      process.exitCode = 1
   })
 }

--- a/tap-snapshots/test-cmd.js-TAP.test.js
+++ b/tap-snapshots/test-cmd.js-TAP.test.js
@@ -2501,7 +2501,7 @@ exports[`test/cmd.js TAP basic passing_child_with_broken_tap t > stderr 1`] = `
 `
 
 exports[`test/cmd.js TAP help > error 1`] = `
-undefined
+0
 `
 
 exports[`test/cmd.js TAP help > output 1`] = `

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -17,17 +17,18 @@ const {runInThisContext} = require('vm')
 const code = require('fs').readFileSync(bin, 'utf8').replace(/^#!.*/, '')
 const EE = require('events')
 const run = (input, args, cb) => {
-  let exitCode = 0
   let stdout = ''
   let stderr = ''
 
   const proc = new EE()
+  proc.exitCode = 0
+
   let exited = false
   proc.exit = code => {
-    exitCode = code || 0
+    proc.exitCode = code || 0
     if (!exited) {
       exited = true
-      cb(code, stdout, stderr)
+      cb(proc.exitCode, stdout, stderr)
     }
   }
   proc.stdin = new Minipass()
@@ -54,7 +55,7 @@ const run = (input, args, cb) => {
 
   if (!exited) {
     exited = true
-    cb(exitCode, stdout, stderr)
+    cb(proc.exitCode, stdout, stderr)
   }
 }
 


### PR DESCRIPTION
Currently the command outputs to stdout by calling
`console.log()`, and if the parsed tap input contains
failures it will forcibly exit the process. This can cause
the process to exit before the stdout stream is flushed.

Instead of `process.exit(1)`, this sets the `exitCode`
and allows the process to exit gracefully.

Potentially related to #50 and #59

Resolves #77 