### PR TITLE
Add failing `destroy()` test

### DIFF
--- a/test/destroy.js
+++ b/test/destroy.js
@@ -1,0 +1,9 @@
+const Parser = require('../')
+const t = require('tap')
+
+t.test('destroy()', function (t) {
+  const stream = new Parser()
+  stream.destroy()
+  t.pass('destroyed')
+  t.end()
+})


### PR DESCRIPTION
A simple test that demonstrates a property conflict between `tap-parser` and `minipass`: both define a `buffer` property on the stream, but [one is a string](https://github.com/tapjs/tap-parser/blob/28eadf8dd647832a0bfe5c9b8ce2d9b0a2943a32/index.js#L261), the [other is an array](https://github.com/isaacs/minipass/blob/66a65348ec33823db3f8dc90e5a60348eb2da600/index.js#L98).

Output of the test:

<details>
<summary>Click to expand</summary>

```
$ node test\destroy.js
TAP version 13
# Subtest: destroy()
    not ok 1 - Cannot assign to read only property 'length' of string ''
      ---
      stack: |
        Parser.destroy (node_modules/minipass/index.js:628:24)
        Test.<anonymous> (test/destroy.js:6:10)
      at:
        line: 628
        column: 24
        file: node_modules/minipass/index.js
        function: Parser.destroy
      type: TypeError
      tapCaught: testFunctionThrow
      test: destroy()
      source: |2
            // throw away all buffered data, it's never coming out
            this.buffer.length = 0
        -----------------------^
            this[BUFFERLENGTH] = 0
      ...

    1..1
    # failed 1 test
not ok 1 - destroy() # time=16.403ms

1..1
# failed 1 test
# time=19.627ms
```

</details>

Looking at git history, the property conflict has been here for a while, but somehow these modules have narrowly escaped an actual bug, until https://github.com/isaacs/minipass/commit/89b823ad685346795b747159661468fc1c2bd060. Would renaming the `buffer` property in `tap-parser` be a good fix?